### PR TITLE
僅在首次啟動時替換PIL Image open save

### DIFF
--- a/scripts/encrypt_image.py
+++ b/scripts/encrypt_image.py
@@ -32,7 +32,6 @@ class EncryptedImage(Image.Image):
         pnginfo.add_text('Encrypt', 'pixel_shuffle')
         super().save(filename, format=self.format, pnginfo=pnginfo, *args, **kwargs)
 
-PILImage.Image = EncryptedImage
         
 def open(fp,*args, **kwargs):
     image = super_open(fp,*args, **kwargs)
@@ -43,7 +42,10 @@ def open(fp,*args, **kwargs):
             return image
     return image
 
-PILImage.open = open
+if not getattr(shared, "sd_webui_encrypt_image", None):
+    shared.sd_webui_encrypt_image = (PILImage.Image, PILImage.open)
+    PILImage.Image = EncryptedImage
+    PILImage.open = open
 
 def on_app_started(demo: Optional[Blocks], app: FastAPI):
     @app.middleware("http")


### PR DESCRIPTION
如果執行"Reload UI"會導致套娃
圖片會被多次加密

我目前的解決方式是把原本的functon 保存在shared內 根據使否以保存來判斷使否已經替換過
之後需要使用原本的functon 時也可從shared調用

---

目前已知其他問題
live preview 的圖貌似沒有加上解密功能

另外 在執行Reload UI後前端的UI圖片解密功能很像也有異常